### PR TITLE
Use already opened transaction

### DIFF
--- a/src/Isolate/Tactician/TransactionMiddleware.php
+++ b/src/Isolate/Tactician/TransactionMiddleware.php
@@ -35,13 +35,13 @@ final class TransactionMiddleware implements Middleware
     public function execute($command, callable $next)
     {
         $context = $this->isolate->getContext($this->contextName);
-        $transaction = $context->openTransaction();
+        $transaction = $context->hasOpenTransaction() ? $context->getTransaction() : $context->openTransaction();
 
         try {
             $returnValue = $next($command);
-            
+
             $context->closeTransaction();
-            
+
             return $returnValue;
         } catch (\Exception $e) {
             $transaction->rollback();


### PR DESCRIPTION
I have command handler which run other command using same command bus. Second run throw `Isolate\Exception\NotClosedTransactionException`. It's fix for that
