### PR TITLE
Don't open and close already existing transaction

### DIFF
--- a/src/Isolate/Tactician/TransactionMiddleware.php
+++ b/src/Isolate/Tactician/TransactionMiddleware.php
@@ -35,7 +35,12 @@ final class TransactionMiddleware implements Middleware
     public function execute($command, callable $next)
     {
         $context = $this->isolate->getContext($this->contextName);
-        $transaction = $context->hasOpenTransaction() ? $context->getTransaction() : $context->openTransaction();
+
+        if ($context->hasOpenTransaction()) {
+            return $next($command);
+        }
+
+        $transaction = $context->openTransaction();
 
         try {
             $returnValue = $next($command);

--- a/tests/Isolate/Tests/SingleTransactionContextStub.php
+++ b/tests/Isolate/Tests/SingleTransactionContextStub.php
@@ -6,12 +6,24 @@ use Isolate\PersistenceContext;
 use Isolate\PersistenceContext\Name;
 use Isolate\PersistenceContext\Transaction;
 
-class SingleTransactionContextStub implements PersistenceContext
+final class SingleTransactionContextStub implements PersistenceContext
 {
     /**
      * @var Transaction
      */
     private $transaction;
+
+    /**
+     * @var bool
+     */
+    private $opened = false;
+
+    public static function createOpened(Transaction $transaction)
+    {
+        $instance = new self($transaction);
+        $instance->opened = true;
+        return $instance;
+    }
 
     /**
      * @param Transaction $transaction
@@ -20,7 +32,7 @@ class SingleTransactionContextStub implements PersistenceContext
     {
         $this->transaction = $transaction;
     }
-    
+
     /**
      * @return Name
      */
@@ -42,7 +54,7 @@ class SingleTransactionContextStub implements PersistenceContext
      */
     public function hasOpenTransaction()
     {
-        return true;
+        return $this->opened;
     }
 
     /**


### PR DESCRIPTION
It's fix for my last pull request. If I have opened transaction I shouldn't open new one and additional I shouldn't close it, because something else should do it.
